### PR TITLE
Führe GitHub Actions Workflows mit Ubuntu 20.04 aus

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -12,7 +12,7 @@ env:
 jobs:
     composer-require-checker:
         name: Check missing composer requirements
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v2
             -   name: Konfiguriere PHP-Version und -Einstellungen im Worker-Node

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
     PHPUnit:
         name: PHPUnit
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v2
             -   run: mkdir --mode=777 -p $GITHUB_WORKSPACE/{tmp,logs}


### PR DESCRIPTION
Der für uns wesentliche Unterschied sollte die Verwendung von MySQL 8 sein. Auf diese Weise können wir testen, ob wir vorwärtskompatibel sind.
