### PR TITLE
Make the tests work (Case 212902)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 phpunit.xml
 .phpunit.result.cache
 .php-cs-fixer.cache
+var/
+logs/

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,11 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^8.5.0",
         "doctrine/common": "^2.0 | ^3.0",
-        "doctrine/persistence": "^1.0",
-        "webfactory/doctrine-orm-test-infrastructure": "^1.7.0"
+        "doctrine/doctrine-bundle": "^2.4",
+        "phpunit/phpunit": "^8.5.0",
+        "symfony/framework-bundle": "^4.4 | ^5.0",
+        "zenstruck/foundry": "^1.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
 
     "require-dev": {
+        "doctrine/annotations": "^1.13 | ^2.0",
         "doctrine/common": "^2.0 | ^3.0",
         "doctrine/doctrine-bundle": "^2.4",
         "phpunit/phpunit": "^8.5.0",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
 
     "autoload-dev": {
         "psr-4": {
+            "App\\": "tests/Fixtures/App",
             "Webfactory\\NewsletterRegistrationBundle\\Tests\\": "tests"
         }
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,9 @@
         <ini name="error_reporting" value="-1" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="KERNEL_CLASS" value="Webfactory\NewsletterRegistrationBundle\Tests\Fixtures\Kernel"/>
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="0"/>
     </php>
 
     <!-- Filter for code coverage -->

--- a/tests/Entity/BlockedEmailAddressHashRepositoryTest.php
+++ b/tests/Entity/BlockedEmailAddressHashRepositoryTest.php
@@ -3,16 +3,18 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use DateTimeImmutable;
-use PHPUnit\Framework\TestCase;
-use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHash;
 use Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHashRepositoryInterface;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
+use Webfactory\NewsletterRegistrationBundle\Tests\Factory\BlockedEmailAddressHashFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
-class BlockedEmailAddressHashRepositoryTest extends TestCase
+class BlockedEmailAddressHashRepositoryTest extends KernelTestCase
 {
-    /** @var ORMInfrastructure */
-    private $infrastructure;
+    use ResetDatabase;
+    use Factories;
 
     /** @var BlockedEmailAddressHashRepositoryInterface */
     private $repository;
@@ -20,8 +22,10 @@ class BlockedEmailAddressHashRepositoryTest extends TestCase
     /** @see \PHPUnit_Framework_TestCase::setUp() */
     protected function setUp(): void
     {
-        $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(BlockedEmailAddressHash::class);
-        $this->repository = $this->infrastructure->getRepository(BlockedEmailAddressHash::class);
+        $this->repository = self::getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getRepository(BlockedEmailAddressHash::class);
     }
 
     /**
@@ -30,12 +34,9 @@ class BlockedEmailAddressHashRepositoryTest extends TestCase
     public function findByEmailAddress_returns_BlockedEmailAddressHash_if_it_exists(): void
     {
         $emailAddress = new EmailAddress('webfactory@example.com', 'secret');
-        $blockedEmailAddressHashFixture = BlockedEmailAddressHash::fromEmailAddress($emailAddress);
+        BlockedEmailAddressHashFactory::createOne(['hash' => $emailAddress->getHash()]);
 
-        $this->infrastructure->import($blockedEmailAddressHashFixture);
-
-        $result = $this->repository->findByEmailAddress($emailAddress);
-        $this->assertNotEmpty($result);
+        $this->assertNotEmpty($this->repository->findByEmailAddress($emailAddress));
     }
 
     /**
@@ -53,12 +54,7 @@ class BlockedEmailAddressHashRepositoryTest extends TestCase
      */
     public function removeOutdated_removes_outdated_ones(): void
     {
-        $this->infrastructure->import(
-            BlockedEmailAddressHash::fromEmailAddress(
-                new EmailAddress('webfactory@example.com', 'secret'),
-                new DateTimeImmutable('2000-01-01')
-            )
-        );
+        BlockedEmailAddressHashFactory::createOne(['blockDate' => new DateTimeImmutable('2000-01-01')]);
 
         $numberOfDeletedOnes = $this->repository->removeOutdated(new DateTimeImmutable());
 
@@ -71,12 +67,7 @@ class BlockedEmailAddressHashRepositoryTest extends TestCase
      */
     public function removeOutdated_does_not_remove_current_ones(): void
     {
-        $this->infrastructure->import(
-            BlockedEmailAddressHash::fromEmailAddress(
-                new EmailAddress('webfactory@example.com', 'secret'),
-                new DateTimeImmutable('-1d')
-            )
-        );
+        BlockedEmailAddressHashFactory::createOne(['blockDate' => new DateTimeImmutable('-1d')]);
 
         $numberOfDeletedOnes = $this->repository->removeOutdated(new DateTimeImmutable('-30d'));
 

--- a/tests/Entity/BlockedEmailAddressHashRepositoryTest.php
+++ b/tests/Entity/BlockedEmailAddressHashRepositoryTest.php
@@ -13,8 +13,8 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 
 class BlockedEmailAddressHashRepositoryTest extends KernelTestCase
 {
-    use ResetDatabase;
     use Factories;
+    use ResetDatabase;
 
     /** @var BlockedEmailAddressHashRepositoryInterface */
     private $repository;

--- a/tests/Entity/NewsletterRepositoryTest.php
+++ b/tests/Entity/NewsletterRepositoryTest.php
@@ -2,15 +2,17 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
-use PHPUnit\Framework\TestCase;
-use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterRepository;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
+use Webfactory\NewsletterRegistrationBundle\Tests\Factory\NewsletterFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
-class NewsletterRepositoryTest extends TestCase
+class NewsletterRepositoryTest extends KernelTestCase
 {
-    /** @var ORMInfrastructure */
-    private $infrastructure;
+    use ResetDatabase;
+    use Factories;
 
     /** @var NewsletterRepository */
     private $repository;
@@ -18,8 +20,10 @@ class NewsletterRepositoryTest extends TestCase
     /** @see \PHPUnit_Framework_TestCase::setUp() */
     protected function setUp(): void
     {
-        $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(Newsletter::class);
-        $this->repository = $this->infrastructure->getRepository(Newsletter::class);
+        $this->repository = self::getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getRepository(Newsletter::class);
     }
 
     /**
@@ -27,8 +31,7 @@ class NewsletterRepositoryTest extends TestCase
      */
     public function findVisible_returns_visible_newsletters()
     {
-        $newsletter = new Newsletter(null, 'test_newsletter');
-        $this->infrastructure->import($newsletter);
+        NewsletterFactory::createOne();
 
         $newsletters = $this->repository->findVisible();
 
@@ -41,12 +44,9 @@ class NewsletterRepositoryTest extends TestCase
      */
     public function findVisible_does_not_return_invisible_newsletters()
     {
-        $newsletter = new Newsletter(null, 'test_newsletter', 0, false);
-        $this->infrastructure->import($newsletter);
+        NewsletterFactory::createOne(['visible' => false]);
 
-        $newsletters = $this->repository->findVisible();
-
-        $this->assertEmpty($newsletters);
+        $this->assertEmpty($this->repository->findVisible());
     }
 
     /**
@@ -54,14 +54,12 @@ class NewsletterRepositoryTest extends TestCase
      */
     public function findVisible_orders_by_rank()
     {
-        $firstNewsletter = new Newsletter(null, '1', 1);
-        $secondNewsletter = new Newsletter(null, '2', 2);
-        $thirdNewsletter = new Newsletter(null, '3', 3);
-
-        $this->infrastructure->import([$firstNewsletter, $thirdNewsletter, $secondNewsletter]);
+        NewsletterFactory::createOne(['name' => '1', 'rank' => 1]);
+        NewsletterFactory::createOne(['name' => '3', 'rank' => 3]);
+        NewsletterFactory::createOne(['name' => '2', 'rank' => 2]);
 
         $newsletters = $this->repository->findVisible();
 
-        $this->assertEquals([$firstNewsletter, $secondNewsletter, $thirdNewsletter], $newsletters);
+        $this->assertEquals(['1', '2', '3'], array_map(fn($n) => $n->getName(), $newsletters));
     }
 }

--- a/tests/Entity/NewsletterRepositoryTest.php
+++ b/tests/Entity/NewsletterRepositoryTest.php
@@ -11,8 +11,8 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 
 class NewsletterRepositoryTest extends KernelTestCase
 {
-    use ResetDatabase;
     use Factories;
+    use ResetDatabase;
 
     /** @var NewsletterRepository */
     private $repository;
@@ -60,6 +60,6 @@ class NewsletterRepositoryTest extends KernelTestCase
 
         $newsletters = $this->repository->findVisible();
 
-        $this->assertEquals(['1', '2', '3'], array_map(fn($n) => $n->getName(), $newsletters));
+        $this->assertEquals(['1', '2', '3'], array_map(fn ($n) => $n->getName(), $newsletters));
     }
 }

--- a/tests/Entity/PendingOptInFactoryTest.php
+++ b/tests/Entity/PendingOptInFactoryTest.php
@@ -2,9 +2,9 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
+use App\PendingOptIn as AppPendingOptIn;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
-use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn;
 use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInFactory;
 use Webfactory\NewsletterRegistrationBundle\StartRegistration\Type as StartRegistrationType;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
@@ -26,10 +26,10 @@ class PendingOptInFactoryTest extends TestCase
      */
     public function fromRegistrationFormData_without_newsletter_choices(): void
     {
-        // The PendingOptInFactory searches for a PendingOptInInterface implementation outside the
-        // Webfactory\NewsletterRegistrationBundle namespace, so let's declare an anonymous one:
-        new class(null, new EmailAddress('webfactory@example.com', 'secret')) extends PendingOptIn {
-        };
+        // The PendingOptInFactory uses get_declared_classes() to find a PendingOptInInterface
+        // implementation outside the Webfactory\NewsletterRegistrationBundle namespace —
+        // the class must be loaded before the factory is called:
+        class_exists(AppPendingOptIn::class);
 
         $pendingOptIn = $this->factory->fromRegistrationFormData([
             StartRegistrationType::ELEMENT_EMAIL_ADDRESS => new EmailAddress('webfactory@example.com', 'secret'),
@@ -43,10 +43,10 @@ class PendingOptInFactoryTest extends TestCase
      */
     public function fromRegistrationFormData_with_newsletter_choices(): void
     {
-        // The PendingOptInFactory searches for a PendingOptInInterface implementation outside the
-        // Webfactory\NewsletterRegistrationBundle namespace, so let's declare an anonymous one:
-        new class(null, new EmailAddress('webfactory@example.com', 'secret')) extends PendingOptIn {
-        };
+        // The PendingOptInFactory uses get_declared_classes() to find a PendingOptInInterface
+        // implementation outside the Webfactory\NewsletterRegistrationBundle namespace —
+        // the class must be loaded before the factory is called:
+        class_exists(AppPendingOptIn::class);
 
         $newslettersForPendingOptIn = [new Newsletter(1, 'newsletter 1')];
         $pendingOptIn = $this->factory->fromRegistrationFormData([

--- a/tests/Entity/PendingOptInRepositoryTest.php
+++ b/tests/Entity/PendingOptInRepositoryTest.php
@@ -3,16 +3,18 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use DateTimeImmutable;
-use PHPUnit\Framework\TestCase;
-use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInRepositoryInterface;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptIn;
+use Webfactory\NewsletterRegistrationBundle\Tests\Factory\PendingOptInFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
-class PendingOptInRepositoryTest extends TestCase
+class PendingOptInRepositoryTest extends KernelTestCase
 {
-    /** @var ORMInfrastructure */
-    private $infrastructure;
+    use ResetDatabase;
+    use Factories;
 
     /** @var PendingOptInRepositoryInterface */
     private $repository;
@@ -20,8 +22,10 @@ class PendingOptInRepositoryTest extends TestCase
     /** @see \PHPUnit_Framework_TestCase::setUp() */
     protected function setUp(): void
     {
-        $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(PendingOptIn::class);
-        $this->repository = $this->infrastructure->getRepository(PendingOptIn::class);
+        $this->repository = self::getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getRepository(PendingOptIn::class);
     }
 
     /**
@@ -29,13 +33,13 @@ class PendingOptInRepositoryTest extends TestCase
      */
     public function findByEmailAddress_returns_PendingOptIn_if_it_exists(): void
     {
-        $alreadyRegisteredEmailAddress = new EmailAddress('webfactory@example.com', 'secret');
-        $pendingOptInFixture = new PendingOptIn('uuid-1', $alreadyRegisteredEmailAddress);
-        $this->infrastructure->import($pendingOptInFixture);
+        $emailAddress = new EmailAddress('webfactory@example.com', 'secret');
+        $proxy = PendingOptInFactory::createOne(['emailAddress' => $emailAddress]);
 
-        $result = $this->repository->findByEmailAddress($alreadyRegisteredEmailAddress);
+        $result = $this->repository->findByEmailAddress($emailAddress);
+
         $this->assertNotEmpty($result);
-        $this->assertEquals($pendingOptInFixture->getUuid(), $result->getUuid());
+        $this->assertEquals($proxy->getUuid(), $result->getUuid());
     }
 
     /**
@@ -53,14 +57,7 @@ class PendingOptInRepositoryTest extends TestCase
      */
     public function removeOutdated_removes_outdated_ones(): void
     {
-        $this->infrastructure->import(
-            new PendingOptIn(
-                'uuid-1',
-                new EmailAddress('webfactory@example.com', 'secret'),
-                [],
-                new DateTimeImmutable('2000-01-01')
-            )
-        );
+        PendingOptInFactory::createOne(['registrationDate' => new DateTimeImmutable('2000-01-01')]);
 
         $numberOfDeletedOnes = $this->repository->removeOutdated(new DateTimeImmutable());
 
@@ -73,14 +70,7 @@ class PendingOptInRepositoryTest extends TestCase
      */
     public function removeOutdated_does_not_remove_current_ones(): void
     {
-        $this->infrastructure->import(
-            new PendingOptIn(
-                'uuid-1',
-                new EmailAddress('webfactory@example.com', 'secret'),
-                [],
-                new DateTimeImmutable('-1h')
-            )
-        );
+        PendingOptInFactory::createOne(['registrationDate' => new DateTimeImmutable('-1h')]);
 
         $numberOfDeletedOnes = $this->repository->removeOutdated(new DateTimeImmutable('-72h'));
 

--- a/tests/Entity/PendingOptInRepositoryTest.php
+++ b/tests/Entity/PendingOptInRepositoryTest.php
@@ -13,8 +13,8 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 
 class PendingOptInRepositoryTest extends KernelTestCase
 {
-    use ResetDatabase;
     use Factories;
+    use ResetDatabase;
 
     /** @var PendingOptInRepositoryInterface */
     private $repository;

--- a/tests/Entity/RecipientFactoryTest.php
+++ b/tests/Entity/RecipientFactoryTest.php
@@ -2,9 +2,9 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
+use App\Recipient as AppRecipient;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
-use Webfactory\NewsletterRegistrationBundle\Entity\Recipient;
 use Webfactory\NewsletterRegistrationBundle\Entity\RecipientFactory;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptIn;
@@ -16,10 +16,10 @@ class RecipientFactoryTest extends TestCase
      */
     public function fromPendingOptIn()
     {
-        // The RecipientFactory searches for a RecipientInterface implementation outside the
-        // Webfactory\NewsletterRegistrationBundle namespace, so let's declare an anonymous one:
-        new class(null, new EmailAddress('webfactory@example.com', null)) extends Recipient {
-        };
+        // The RecipientFactory uses get_declared_classes() to find a RecipientInterface
+        // implementation outside the Webfactory\NewsletterRegistrationBundle namespace —
+        // the class must be loaded before the factory is called:
+        class_exists(AppRecipient::class);
 
         $newslettersForPendingOptIn = [new Newsletter(1, 'newsletter 1')];
         $recipient = (new RecipientFactory())->fromPendingOptIn(

--- a/tests/Entity/RecipientRepositoryTest.php
+++ b/tests/Entity/RecipientRepositoryTest.php
@@ -12,8 +12,8 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 
 class RecipientRepositoryTest extends KernelTestCase
 {
-    use ResetDatabase;
     use Factories;
+    use ResetDatabase;
 
     /** @var RecipientRepositoryInterface */
     private $repository;

--- a/tests/Entity/RecipientRepositoryTest.php
+++ b/tests/Entity/RecipientRepositoryTest.php
@@ -2,16 +2,18 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
-use PHPUnit\Framework\TestCase;
-use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Entity\RecipientRepositoryInterface;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Recipient;
+use Webfactory\NewsletterRegistrationBundle\Tests\Factory\RecipientFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
-class RecipientRepositoryTest extends TestCase
+class RecipientRepositoryTest extends KernelTestCase
 {
-    /** @var ORMInfrastructure */
-    private $infrastructure;
+    use ResetDatabase;
+    use Factories;
 
     /** @var RecipientRepositoryInterface */
     private $repository;
@@ -19,8 +21,10 @@ class RecipientRepositoryTest extends TestCase
     /** @see \PHPUnit_Framework_TestCase::setUp() */
     protected function setUp(): void
     {
-        $this->infrastructure = ORMInfrastructure::createWithDependenciesFor(Recipient::class);
-        $this->repository = $this->infrastructure->getRepository(Recipient::class);
+        $this->repository = self::getContainer()
+            ->get('doctrine')
+            ->getManager()
+            ->getRepository(Recipient::class);
     }
 
     /**
@@ -28,12 +32,13 @@ class RecipientRepositoryTest extends TestCase
      */
     public function isEmailAddressAlreadyRegistered_returns_true_if_already_registered()
     {
-        $recipientFixture = new Recipient('uuid-1', new EmailAddress('webfactory@example.com', null));
-        $this->infrastructure->import($recipientFixture);
+        $emailAddress = new EmailAddress('webfactory@example.com', null);
+        $registeredRecipient = RecipientFactory::createOne(['emailAddress' => $emailAddress]);
 
-        $retrievedRecipient = $this->repository->findByEmailAddress($recipientFixture->getEmailAddress());
+        $retrievedRecipient = $this->repository->findByEmailAddress($emailAddress);
+
         $this->assertNotNull($retrievedRecipient);
-        $this->assertEquals($recipientFixture->getUuid(), $retrievedRecipient->getUuid());
+        $this->assertEquals($registeredRecipient->getUuid(), $retrievedRecipient->getUuid());
     }
 
     /**

--- a/tests/Factory/BlockedEmailAddressHashFactory.php
+++ b/tests/Factory/BlockedEmailAddressHashFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Factory;
+
+use DateTimeImmutable;
+use Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHash;
+use Zenstruck\Foundry\ModelFactory;
+
+final class BlockedEmailAddressHashFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'hash' => self::faker()->sha1(),
+            'blockDate' => new DateTimeImmutable(),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this->instantiateWith(function (array $attributes): BlockedEmailAddressHash {
+            return new BlockedEmailAddressHash($attributes['hash'], $attributes['blockDate']);
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return BlockedEmailAddressHash::class;
+    }
+}

--- a/tests/Factory/NewsletterFactory.php
+++ b/tests/Factory/NewsletterFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Factory;
+
+use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
+use Zenstruck\Foundry\ModelFactory;
+
+final class NewsletterFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'name' => self::faker()->word(),
+            'rank' => 0,
+            'visible' => true,
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this->instantiateWith(function (array $attributes): Newsletter {
+            return new Newsletter(null, $attributes['name'], $attributes['rank'], $attributes['visible']);
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return Newsletter::class;
+    }
+}

--- a/tests/Factory/PendingOptInFactory.php
+++ b/tests/Factory/PendingOptInFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Factory;
+
+use DateTimeImmutable;
+use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
+use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptIn;
+use Zenstruck\Foundry\ModelFactory;
+
+final class PendingOptInFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'uuid' => self::faker()->uuid(),
+            'emailAddress' => new EmailAddress(self::faker()->email(), 'secret'),
+            'registrationDate' => new DateTimeImmutable(),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this->instantiateWith(function (array $attributes): PendingOptIn {
+            return new PendingOptIn(
+                $attributes['uuid'],
+                $attributes['emailAddress'],
+                [],
+                $attributes['registrationDate']
+            );
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return PendingOptIn::class;
+    }
+}

--- a/tests/Factory/RecipientFactory.php
+++ b/tests/Factory/RecipientFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Factory;
+
+use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
+use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Recipient;
+use Zenstruck\Foundry\ModelFactory;
+
+final class RecipientFactory extends ModelFactory
+{
+    protected function getDefaults(): array
+    {
+        return [
+            'uuid' => self::faker()->uuid(),
+            'emailAddress' => new EmailAddress(self::faker()->email(), null),
+        ];
+    }
+
+    protected function initialize(): self
+    {
+        return $this->instantiateWith(function (array $attributes): Recipient {
+            return new Recipient($attributes['uuid'], $attributes['emailAddress']);
+        });
+    }
+
+    protected static function getClass(): string
+    {
+        return Recipient::class;
+    }
+}

--- a/tests/Fixtures/App/PendingOptIn.php
+++ b/tests/Fixtures/App/PendingOptIn.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App;
+
+class PendingOptIn extends \Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn
+{
+}

--- a/tests/Fixtures/App/README.md
+++ b/tests/Fixtures/App/README.md
@@ -1,0 +1,7 @@
+# App namespace for automatic implementation detection tests
+
+Some factories in this bundle try to detect implementation classes by filtering out classes in namespaces starting
+with `Webfactory\NewsletterRegistrationBundle`. This is why we need this extra namespace, included separately in the
+`composer.json`, to provide the test with implementations to find.
+
+See `DetermineAppsSubclassTrait::getAppsSubclassOf()`.

--- a/tests/Fixtures/App/Recipient.php
+++ b/tests/Fixtures/App/Recipient.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App;
+
+class Recipient extends \Webfactory\NewsletterRegistrationBundle\Entity\Recipient
+{
+}

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Fixtures;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Zenstruck\Foundry\ZenstruckFoundryBundle;
+
+class Kernel extends BaseKernel
+{
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineBundle(),
+            new ZenstruckFoundryBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(__DIR__.'/config/framework.php');
+        $loader->load(__DIR__.'/config/doctrine.php');
+        $loader->load(__DIR__.'/config/zenstruck_foundry.php');
+    }
+
+    public function getCacheDir(): string
+    {
+        return __DIR__.'/../../var/cache/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return __DIR__.'/../../logs';
+    }
+}

--- a/tests/Fixtures/config/doctrine.php
+++ b/tests/Fixtures/config/doctrine.php
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('doctrine', [
+        'dbal' => [
+            'driver' => 'pdo_sqlite',
+            'path' => '%kernel.cache_dir%/test.db',
+        ],
+        'orm' => [
+            'auto_generate_proxy_classes' => true,
+            'mappings' => [
+                'BundleEntities' => [
+                    'is_bundle' => false,
+                    'type' => 'annotation',
+                    'dir' => '%kernel.project_dir%/src/Entity',
+                    'prefix' => 'Webfactory\\NewsletterRegistrationBundle\\Entity',
+                    'alias' => 'Bundle',
+                ],
+                'TestEntities' => [
+                    'is_bundle' => false,
+                    'type' => 'annotation',
+                    'dir' => '%kernel.project_dir%/tests/Entity/Dummy',
+                    'prefix' => 'Webfactory\\NewsletterRegistrationBundle\\Tests\\Entity\\Dummy',
+                    'alias' => 'Test',
+                ],
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/config/framework.php
+++ b/tests/Fixtures/config/framework.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('framework', [
+        'secret' => 'test-secret',
+        'test' => true,
+    ]);
+};

--- a/tests/Fixtures/config/zenstruck_foundry.php
+++ b/tests/Fixtures/config/zenstruck_foundry.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('zenstruck_foundry', []);
+};


### PR DESCRIPTION
Makes the tests work by

- porting tests away from webfactory/doctrine-orm-test-infrastucture in favour of zenstruck/foundry
- fixing a PHP 8 compatibility issue

Before this, the dev composer dependencies could not be resolved to an installable set of packages, which made the tests unable to run (both in CI and locally).

5715c37a2770875caadb08d77bfdd1a2b8f200f4 was an attempt to fix this by upgrading the PHP version in the CI runner (the error message of the CI fail at this point suggested incompatibilities with the PHP version and I did not want to downgrade any of the libraries), but the new PHP version was incompatible with the requested version of webfactory/doctrine-orm-test-infrastucture.

I decided that webfactory/doctrine-orm-test-infrastucture is not the future, so instead of upgrading it, this removes the dependency by porting the tests to zenstruck/foundry.

The KernelTestCase/Foundry implementation still uses a temporary SQLite database. We should migrate to using a real MySQL database in the future, but this is out of scope of this PR.

In my earlier attempt to fix the CI pipeline by upgrading the PHP version only, I did not account for a change in PHP that broke a test (which I could not see at that point as the attempt failed at making the dependencies installable). This got fixed in 7c2abfec9c6ecb8b9035993278453a76e786efc5.