### PR TITLE
Refactoring: Turn getAppsSubclassOf helper into static function

### DIFF
--- a/src/Entity/DetermineAppsSubclassHelper.php
+++ b/src/Entity/DetermineAppsSubclassHelper.php
@@ -4,9 +4,9 @@ namespace Webfactory\NewsletterRegistrationBundle\Entity;
 
 use Exception;
 
-trait DetermineAppsSubclassTrait
+class DetermineAppsSubclassHelper
 {
-    protected function getAppsSubclassOf(string $parentClass, Exception $exceptionToThrowIfNotDeterminable): ?string
+    public static function getAppsSubclassOf(string $parentClass, Exception $exceptionToThrowIfNotDeterminable): ?string
     {
         foreach (get_declared_classes() as $class) {
             if (

--- a/src/Entity/PendingOptInFactory.php
+++ b/src/Entity/PendingOptInFactory.php
@@ -10,11 +10,9 @@ use Webfactory\NewsletterRegistrationBundle\Exception\PendingOptInClassCouldNotB
  */
 class PendingOptInFactory implements PendingOptInFactoryInterface
 {
-    use DetermineAppsSubclassTrait;
-
     public function fromRegistrationFormData(array $formData): ?PendingOptInInterface
     {
-        $appsPendingOptInClass = $this->getAppsSubclassOf(
+        $appsPendingOptInClass = DetermineAppsSubclassHelper::getAppsSubclassOf(
             PendingOptInInterface::class,
             new PendingOptInClassCouldNotBeDeterminedException()
         );

--- a/src/Entity/RecipientFactory.php
+++ b/src/Entity/RecipientFactory.php
@@ -10,11 +10,9 @@ use Webfactory\NewsletterRegistrationBundle\Exception\RecipientClassCouldNotBeDe
  */
 class RecipientFactory implements RecipientFactoryInterface
 {
-    use DetermineAppsSubclassTrait;
-
     public function fromPendingOptIn(PendingOptInInterface $pendingOptIn): RecipientInterface
     {
-        $appsRecipientClass = $this->getAppsSubclassOf(
+        $appsRecipientClass = DetermineAppsSubclassHelper::getAppsSubclassOf(
             RecipientInterface::class,
             new RecipientClassCouldNotBeDeterminedException()
         );


### PR DESCRIPTION
The helper function has no dependency on the class from which it's called, so no trait is needed.