### PR TITLE
Migrate Controller routing from SensioFrameworkExtraBundle to native attributes (Case 212955)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,11 @@
         "doctrine/common": "^2.0 | ^3.0",
         "doctrine/doctrine-bundle": "^2.4",
         "phpunit/phpunit": "^8.5.0",
+        "symfony/browser-kit": "^7.4",
+        "symfony/css-selector": "^7.4",
         "symfony/framework-bundle": "^4.4 | ^5.0",
+        "symfony/twig-bundle": "^4.4|^5.0",
+        "symfony/yaml": "^6.4",
         "zenstruck/foundry": "^1.0"
     },
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -3,12 +3,12 @@
 namespace Webfactory\NewsletterRegistrationBundle;
 
 use DateInterval;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 use Webfactory\NewsletterRegistrationBundle\BlockEmails\TaskInterface as BlockEmailsTaskInterface;
@@ -81,9 +81,7 @@ class Controller
         $this->recipientRepository = $recipientRepository;
     }
 
-    /**
-     * @Route("/", name="newsletter-registration-start")
-     */
+    #[Route('/', name: 'newsletter-registration-start')]
     public function startRegistration(Request $request): Response
     {
         $form = $this->formFactory->createNamed('', StartRegistrationType::class);
@@ -116,9 +114,7 @@ class Controller
         );
     }
 
-    /**
-     * @Route("/{uuid}/{emailAddress}/", name="newsletter-registration-confirm", requirements={"uuid": "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}", "emailAddress": ".*@((?!\/).)*"})
-     */
+    #[Route('/{uuid}/{emailAddress}/', name: 'newsletter-registration-confirm', requirements: ['uuid' => '([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}', 'emailAddress' => '.*@((?!\/).)*'])]
     public function confirmRegistration(string $uuid, string $emailAddress): Response
     {
         $pendingOptIn = $this->pendingOptInRepository->findByUuid($uuid);
@@ -162,9 +158,7 @@ class Controller
         );
     }
 
-    /**
-     * @Route("/{uuid}/", name="newsletter-registration-edit", requirements={"uuid": "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}"})
-     */
+    #[Route('/{uuid}/', name: 'newsletter-registration-edit', requirements: ['uuid' => '([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}'])]
     public function editRegistration(string $uuid, Request $request): Response
     {
         $recipient = $this->recipientRepository->findByUuid($uuid);
@@ -205,11 +199,7 @@ class Controller
         );
     }
 
-    /**
-     * @Route("/{uuid}/delete/", name="newsletter-registration-delete", methods={"POST"}, requirements={"uuid": "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}"})
-     *
-     * @return RedirectResponse|Response
-     */
+    #[Route('/{uuid}/delete/', name: 'newsletter-registration-delete', methods: ['POST'], requirements: ['uuid' => '([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}'])]
     public function deleteRegistration(string $uuid): Response
     {
         $recipient = $this->recipientRepository->findByUuid($uuid);
@@ -227,11 +217,7 @@ class Controller
         );
     }
 
-    /**
-     * @Route("/{uuid}/{emailAddress}/block/", name="newsletter-registration-block-emails", requirements={"uuid": "([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}", "emailAddress": ".*@.*"})
-     *
-     * @return RedirectResponse|Response
-     */
+    #[Route('/{uuid}/{emailAddress}/block/', name: 'newsletter-registration-block-emails', requirements: ['uuid' => '([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}', 'emailAddress' => '.*@.*'])]
     public function blockEmails(string $uuid, string $emailAddress, Request $request): Response
     {
         $pendingOptIn = $this->pendingOptInRepository->findByUuid($uuid);

--- a/tests/Fixtures/Kernel.php
+++ b/tests/Fixtures/Kernel.php
@@ -4,8 +4,10 @@ namespace Webfactory\NewsletterRegistrationBundle\Tests\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Webfactory\NewsletterRegistrationBundle\WebfactoryNewsletterRegistrationBundle;
 use Zenstruck\Foundry\ZenstruckFoundryBundle;
 
 class Kernel extends BaseKernel
@@ -16,6 +18,8 @@ class Kernel extends BaseKernel
             new FrameworkBundle(),
             new DoctrineBundle(),
             new ZenstruckFoundryBundle(),
+            new TwigBundle(),
+            new WebfactoryNewsletterRegistrationBundle(),
         ];
     }
 
@@ -24,6 +28,8 @@ class Kernel extends BaseKernel
         $loader->load(__DIR__.'/config/framework.php');
         $loader->load(__DIR__.'/config/doctrine.php');
         $loader->load(__DIR__.'/config/zenstruck_foundry.php');
+        $loader->load(__DIR__.'/config/twig.php');
+        $loader->load(__DIR__.'/config/functional_services.php');
     }
 
     public function getCacheDir(): string

--- a/tests/Fixtures/config/functional_services.php
+++ b/tests/Fixtures/config/functional_services.php
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterRepositoryInterface;
+use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInRepositoryInterface;
+use Webfactory\NewsletterRegistrationBundle\Entity\RecipientRepositoryInterface;
+use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
+use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptIn;
+use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Recipient;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->parameters()
+        ->set('webfactory.newsletter_registration.secret', 'test-secret')
+        ->set('webfactory.newsletter_registration.email_sender_address', 'newsletter@example.com');
+
+    $containerConfigurator->extension('framework', [
+        'router' => [
+            'resource' => '%kernel.project_dir%/tests/Fixtures/config/routes.php',
+            'utf8' => true,
+        ],
+        'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
+        'mailer' => ['dsn' => 'null://null'],
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    $services->set(PendingOptInRepositoryInterface::class)
+        ->factory([service('doctrine.orm.entity_manager'), 'getRepository'])
+        ->args([PendingOptIn::class]);
+
+    $services->set(RecipientRepositoryInterface::class)
+        ->factory([service('doctrine.orm.entity_manager'), 'getRepository'])
+        ->args([Recipient::class]);
+
+    $services->set(NewsletterRepositoryInterface::class)
+        ->factory([service('doctrine.orm.entity_manager'), 'getRepository'])
+        ->args([Newsletter::class]);
+};

--- a/tests/Fixtures/config/routes.php
+++ b/tests/Fixtures/config/routes.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->import(__DIR__.'/../../../src/Controller.php', 'annotation');
+};

--- a/tests/Fixtures/config/twig.php
+++ b/tests/Fixtures/config/twig.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('twig', [
+        'paths' => [
+            '%kernel.project_dir%/src/Resources/views' => 'WebfactoryNewsletterRegistration',
+        ],
+        'form_themes' => ['form_div_layout.html.twig'],
+    ]);
+};

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class ControllerTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    /** @test */
+    public function start_registration_route_renders_the_registration_form(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form');
+    }
+
+    /** @test */
+    public function edit_registration_route_returns_not_found_for_unknown_uuid(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11/');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+}


### PR DESCRIPTION
Controller.php imported Sensio\Bundle\FrameworkExtraBundle\Configuration\Route,
(which is abandoned and was never declared in composer.json, leaving a dead
import that composer-require-checker cannot resolve). Replace the 5 @route
docblock annotations with native #[Route(...)] PHP 8 attributes from
Symfony\Component\Routing\Annotation\Route (still the correct namespace on
Symfony 5; the interim Symfony 7 bump switches it to Attribute\Route).

This prepares for the upgrade to Symfony 7.