### PR TITLE
 Doctrine 3 preparation: Migrate Doctrine ORM annotations to PHP 8 attributes (Case 212955)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
 
     "require-dev": {
-        "doctrine/annotations": "^1.13 | ^2.0",
         "doctrine/common": "^2.0 | ^3.0",
         "doctrine/doctrine-bundle": "^2.4",
         "phpunit/phpunit": "^8.5.0",

--- a/src/Entity/BlockedEmailAddressHash.php
+++ b/src/Entity/BlockedEmailAddressHash.php
@@ -6,24 +6,14 @@ use DateInterval;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity(repositoryClass="\Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHashRepository")
- */
+#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHashRepository')]
 class BlockedEmailAddressHash implements BlockedEmailAddressHashInterface
 {
-    /**
-     * @ORM\Column(type="string", nullable=false)
-     * @ORM\Id
-     *
-     * @var string
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'string', nullable: false)]
     protected $hash;
 
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=false)
-     *
-     * @var DateTimeImmutable
-     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: false)]
     protected $blockDate;
 
     public static function fromEmailAddress(

--- a/src/Entity/BlockedEmailAddressHash.php
+++ b/src/Entity/BlockedEmailAddressHash.php
@@ -9,10 +9,16 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: BlockedEmailAddressHashRepository::class)]
 class BlockedEmailAddressHash implements BlockedEmailAddressHashInterface
 {
+    /**
+     * @var string
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'string', nullable: false)]
     protected $hash;
 
+    /**
+     * @var DateTimeImmutable
+     */
     #[ORM\Column(type: 'datetime_immutable', nullable: false)]
     protected $blockDate;
 

--- a/src/Entity/BlockedEmailAddressHash.php
+++ b/src/Entity/BlockedEmailAddressHash.php
@@ -6,7 +6,7 @@ use DateInterval;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHashRepository')]
+#[ORM\Entity(repositoryClass: BlockedEmailAddressHashRepository::class)]
 class BlockedEmailAddressHash implements BlockedEmailAddressHashInterface
 {
     #[ORM\Id]

--- a/src/Entity/Newsletter.php
+++ b/src/Entity/Newsletter.php
@@ -10,18 +10,31 @@ use Doctrine\ORM\Mapping as ORM;
  */
 abstract class Newsletter implements NewsletterInterface
 {
+    /**
+     * @var int|null
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer', nullable: false)]
     protected $id;
 
+    /**
+     * @var string
+     */
     #[ORM\Column(type: 'string', nullable: false)]
     protected $name;
 
+    /**
+     * @var bool
+     */
     #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => true])]
     protected $visible;
 
-    /** Used for sorting amongst other Newsletters. */
+    /**
+     * @var int
+     *
+     * Used for sorting amongst other Newsletters.
+     */
     #[ORM\Column(type: 'integer', nullable: false, options: ['default' => 0])]
     protected $rank;
 

--- a/src/Entity/Newsletter.php
+++ b/src/Entity/Newsletter.php
@@ -10,36 +10,19 @@ use Doctrine\ORM\Mapping as ORM;
  */
 abstract class Newsletter implements NewsletterInterface
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer", nullable=false)
-     *
-     * @var int|null
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer', nullable: false)]
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=false)
-     *
-     * @var string
-     */
+    #[ORM\Column(type: 'string', nullable: false)]
     protected $name;
 
-    /**
-     * @ORM\Column(type="boolean", nullable=false, options={"default": true})
-     *
-     * @var bool
-     */
+    #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => true])]
     protected $visible;
 
-    /**
-     * @ORM\Column(type="integer", nullable=false, options={"default": 0})
-     *
-     * @var int
-     *
-     * Used for sorting amongst other Newsletters.
-     */
+    /** Used for sorting amongst other Newsletters. */
+    #[ORM\Column(type: 'integer', nullable: false, options: ['default' => 0])]
     protected $rank;
 
     public function __construct(?int $id, string $name, int $rank = 0, $visible = true)

--- a/src/Entity/PendingOptIn.php
+++ b/src/Entity/PendingOptIn.php
@@ -5,7 +5,6 @@ namespace Webfactory\NewsletterRegistrationBundle\Entity;
 use DateInterval;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 use Webfactory\NewsletterRegistrationBundle\Exception\EmailAddressDoesNotMatchHashOfPendingOptInException;
@@ -22,46 +21,25 @@ use Webfactory\NewsletterRegistrationBundle\StartRegistration\Type as StartRegis
  */
 abstract class PendingOptIn implements PendingOptInInterface
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="string", length=36, unique=true, nullable=false)
-     *
-     * @var string
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'string', length: 36, unique: true, nullable: false)]
     protected $uuid;
 
-    /**
-     * @var EmailAddress
-     *
-     * Not ORM-mapped since we don't want to store personal data before confirmation.
-     */
+    /** Not ORM-mapped since we don't want to store personal data before confirmation. */
     protected $emailAddress;
 
-    /**
-     * @ORM\Column(type="string", nullable=false)
-     *
-     * @var string
-     *
-     * Hash of normalized email address.
-     */
+    /** Hash of normalized email address. */
+    #[ORM\Column(type: 'string', nullable: false)]
     protected $emailAddressHash;
 
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=false)
-     *
-     * @var DateTimeImmutable
-     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: false)]
     protected $registrationDate;
 
-    /**
-     * @ORM\ManyToMany(targetEntity="Webfactory\NewsletterRegistrationBundle\Entity\NewsletterInterface")
-     * @ORM\JoinTable(
-     *     joinColumns={@ORM\JoinColumn(referencedColumnName="uuid", onDelete="CASCADE")},
-     *     inverseJoinColumns={@ORM\JoinColumn(onDelete="CASCADE")}
-     * )
-     *
-     * @var Collection of NewsletterInterface
-     */
+    #[ORM\ManyToMany(targetEntity: NewsletterInterface::class)]
+    #[ORM\JoinTable(
+        joinColumns: [new ORM\JoinColumn(referencedColumnName: 'uuid', onDelete: 'CASCADE')],
+        inverseJoinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')]
+    )]
     protected $newsletters;
 
     public static function fromRegistrationFormData(array $formData): ?PendingOptInInterface

--- a/src/Entity/PendingOptIn.php
+++ b/src/Entity/PendingOptIn.php
@@ -5,6 +5,7 @@ namespace Webfactory\NewsletterRegistrationBundle\Entity;
 use DateInterval;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 use Webfactory\NewsletterRegistrationBundle\Exception\EmailAddressDoesNotMatchHashOfPendingOptInException;
@@ -21,20 +22,37 @@ use Webfactory\NewsletterRegistrationBundle\StartRegistration\Type as StartRegis
  */
 abstract class PendingOptIn implements PendingOptInInterface
 {
+    /**
+     * @var string
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'string', length: 36, unique: true, nullable: false)]
     protected $uuid;
 
-    /** Not ORM-mapped since we don't want to store personal data before confirmation. */
+    /**
+     * @var EmailAddress
+     *
+     * Not ORM-mapped since we don't want to store personal data before confirmation.
+     */
     protected $emailAddress;
 
-    /** Hash of normalized email address. */
+    /**
+     * @var string
+     *
+     * Hash of normalized email address.
+     */
     #[ORM\Column(type: 'string', nullable: false)]
     protected $emailAddressHash;
 
+    /**
+     * @var DateTimeImmutable
+     */
     #[ORM\Column(type: 'datetime_immutable', nullable: false)]
     protected $registrationDate;
 
+    /**
+     * @var Collection of NewsletterInterface
+     */
     #[ORM\ManyToMany(targetEntity: NewsletterInterface::class)]
     #[ORM\JoinTable(
         joinColumns: [new ORM\JoinColumn(referencedColumnName: 'uuid', onDelete: 'CASCADE')],

--- a/src/Entity/Recipient.php
+++ b/src/Entity/Recipient.php
@@ -4,7 +4,6 @@ namespace Webfactory\NewsletterRegistrationBundle\Entity;
 
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 
@@ -21,48 +20,28 @@ use Ramsey\Uuid\Uuid;
 abstract class Recipient implements RecipientInterface
 {
     /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer", nullable=false)
-     *
-     * @var int|null
-     *
      * This id is used for external webfactory purposes. You may remove it and declare uuid as your primary key.
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer', nullable: false)]
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", length=36, unique=true, nullable=false)
-     *
-     * @var string
-     */
+    #[ORM\Column(type: 'string', length: 36, unique: true, nullable: false)]
     protected $uuid;
 
-    /**
-     * @ORM\Column(type="string", name="email", nullable=false)
-     *
-     * @var string
-     *
-     * Normalized email address.
-     */
+    /** Normalized email address. */
+    #[ORM\Column(type: 'string', name: 'email', nullable: false)]
     protected $emailAddress;
 
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=false)
-     *
-     * @var DateTimeImmutable
-     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: false)]
     protected $optInDate;
 
-    /**
-     * @ORM\ManyToMany(targetEntity="Webfactory\NewsletterRegistrationBundle\Entity\NewsletterInterface")
-     * @ORM\JoinTable(
-     *     joinColumns={@ORM\JoinColumn(onDelete="CASCADE")},
-     *     inverseJoinColumns={@ORM\JoinColumn(onDelete="CASCADE")}
-     * )
-     *
-     * @var Collection of NewsletterInterface
-     */
+    #[ORM\ManyToMany(targetEntity: NewsletterInterface::class)]
+    #[ORM\JoinTable(
+        joinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')],
+        inverseJoinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')]
+    )]
     protected $newsletters;
 
     public static function fromPendingOptIn(PendingOptInInterface $pendingOptIn): RecipientInterface

--- a/src/Entity/Recipient.php
+++ b/src/Entity/Recipient.php
@@ -4,6 +4,7 @@ namespace Webfactory\NewsletterRegistrationBundle\Entity;
 
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 
@@ -20,6 +21,8 @@ use Ramsey\Uuid\Uuid;
 abstract class Recipient implements RecipientInterface
 {
     /**
+     * @var int|null
+     *
      * This id is used for external webfactory purposes. You may remove it and declare uuid as your primary key.
      */
     #[ORM\Id]
@@ -27,16 +30,29 @@ abstract class Recipient implements RecipientInterface
     #[ORM\Column(type: 'integer', nullable: false)]
     protected $id;
 
+    /**
+     * @var string
+     */
     #[ORM\Column(type: 'string', length: 36, unique: true, nullable: false)]
     protected $uuid;
 
-    /** Normalized email address. */
+    /**
+     * @var string
+     *
+     * Normalized email address.
+     */
     #[ORM\Column(type: 'string', name: 'email', nullable: false)]
     protected $emailAddress;
 
+    /**
+     * @var DateTimeImmutable
+     */
     #[ORM\Column(type: 'datetime_immutable', nullable: false)]
     protected $optInDate;
 
+    /**
+     * @var Collection of NewsletterInterface
+     */
     #[ORM\ManyToMany(targetEntity: NewsletterInterface::class)]
     #[ORM\JoinTable(
         joinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')],

--- a/tests/Entity/Dummy/Newsletter.php
+++ b/tests/Entity/Dummy/Newsletter.php
@@ -4,7 +4,7 @@ namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\NewsletterRepository')]
+#[ORM\Entity(repositoryClass: NewsletterRepository::class)]
 class Newsletter extends \Webfactory\NewsletterRegistrationBundle\Entity\Newsletter
 {
 }

--- a/tests/Entity/Dummy/Newsletter.php
+++ b/tests/Entity/Dummy/Newsletter.php
@@ -4,9 +4,7 @@ namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity(repositoryClass="\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\NewsletterRepository")
- */
+#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\NewsletterRepository')]
 class Newsletter extends \Webfactory\NewsletterRegistrationBundle\Entity\Newsletter
 {
 }

--- a/tests/Entity/Dummy/PendingOptIn.php
+++ b/tests/Entity/Dummy/PendingOptIn.php
@@ -2,11 +2,15 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PendingOptInRepository::class)]
 class PendingOptIn extends \Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn
 {
+    /**
+     * @var Collection of Newsletter
+     */
     #[ORM\ManyToMany(targetEntity: Newsletter::class)]
     #[ORM\JoinTable(
         joinColumns: [new ORM\JoinColumn(referencedColumnName: 'uuid', onDelete: 'CASCADE')],

--- a/tests/Entity/Dummy/PendingOptIn.php
+++ b/tests/Entity/Dummy/PendingOptIn.php
@@ -4,7 +4,7 @@ namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptInRepository')]
+#[ORM\Entity(repositoryClass: PendingOptInRepository::class)]
 class PendingOptIn extends \Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn
 {
     #[ORM\ManyToMany(targetEntity: Newsletter::class)]

--- a/tests/Entity/Dummy/PendingOptIn.php
+++ b/tests/Entity/Dummy/PendingOptIn.php
@@ -2,22 +2,15 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity(repositoryClass="\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptInRepository")
- */
+#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptInRepository')]
 class PendingOptIn extends \Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn
 {
-    /**
-     * @ORM\ManyToMany(targetEntity="Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter")
-     * @ORM\JoinTable(
-     *     joinColumns={@ORM\JoinColumn(referencedColumnName="uuid", onDelete="CASCADE")},
-     *     inverseJoinColumns={@ORM\JoinColumn(onDelete="CASCADE")}
-     * )
-     *
-     * @var Collection of Newsletter
-     */
+    #[ORM\ManyToMany(targetEntity: Newsletter::class)]
+    #[ORM\JoinTable(
+        joinColumns: [new ORM\JoinColumn(referencedColumnName: 'uuid', onDelete: 'CASCADE')],
+        inverseJoinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')]
+    )]
     protected $newsletters;
 }

--- a/tests/Entity/Dummy/Recipient.php
+++ b/tests/Entity/Dummy/Recipient.php
@@ -2,11 +2,15 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: RecipientRepository::class)]
 class Recipient extends \Webfactory\NewsletterRegistrationBundle\Entity\Recipient
 {
+    /**
+     * @var Collection of Newsletter
+     */
     #[ORM\ManyToMany(targetEntity: Newsletter::class)]
     #[ORM\JoinTable(
         joinColumns: [new ORM\JoinColumn(referencedColumnName: 'uuid', onDelete: 'CASCADE')],

--- a/tests/Entity/Dummy/Recipient.php
+++ b/tests/Entity/Dummy/Recipient.php
@@ -4,7 +4,7 @@ namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\RecipientRepository')]
+#[ORM\Entity(repositoryClass: RecipientRepository::class)]
 class Recipient extends \Webfactory\NewsletterRegistrationBundle\Entity\Recipient
 {
     #[ORM\ManyToMany(targetEntity: Newsletter::class)]

--- a/tests/Entity/Dummy/Recipient.php
+++ b/tests/Entity/Dummy/Recipient.php
@@ -2,22 +2,15 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy;
 
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity(repositoryClass="\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\RecipientRepository")
- */
+#[ORM\Entity(repositoryClass: '\Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\RecipientRepository')]
 class Recipient extends \Webfactory\NewsletterRegistrationBundle\Entity\Recipient
 {
-    /**
-     * @ORM\ManyToMany(targetEntity="Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter")
-     * @ORM\JoinTable(
-     *     joinColumns={@ORM\JoinColumn(referencedColumnName="uuid", onDelete="CASCADE")},
-     *     inverseJoinColumns={@ORM\JoinColumn(onDelete="CASCADE")}
-     * )
-     *
-     * @var Collection of Newsletter
-     */
+    #[ORM\ManyToMany(targetEntity: Newsletter::class)]
+    #[ORM\JoinTable(
+        joinColumns: [new ORM\JoinColumn(referencedColumnName: 'uuid', onDelete: 'CASCADE')],
+        inverseJoinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')]
+    )]
     protected $newsletters;
 }

--- a/tests/Fixtures/config/doctrine.php
+++ b/tests/Fixtures/config/doctrine.php
@@ -13,14 +13,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'mappings' => [
                 'BundleEntities' => [
                     'is_bundle' => false,
-                    'type' => 'annotation',
+                    'type' => 'attribute',
                     'dir' => '%kernel.project_dir%/src/Entity',
                     'prefix' => 'Webfactory\\NewsletterRegistrationBundle\\Entity',
                     'alias' => 'Bundle',
                 ],
                 'TestEntities' => [
                     'is_bundle' => false,
-                    'type' => 'annotation',
+                    'type' => 'attribute',
                     'dir' => '%kernel.project_dir%/tests/Entity/Dummy',
                     'prefix' => 'Webfactory\\NewsletterRegistrationBundle\\Tests\\Entity\\Dummy',
                     'alias' => 'Test',


### PR DESCRIPTION
Doctrine ORM 3 removes the annotation driver. Convert all active `@Orm\*`
docblock annotations in the entity classes and test dummy entities to
`#[ORM\*]` attributes, and switch both Doctrine test mappings from the
'annotation' to the 'attribute' driver. Drop doctrine/annotations from
require-dev, as nothing needs it anymore. Verified against the installed
ORM 2.20 attribute driver so the suite stays green before the version bump.