### PR TITLE
PHP 8.4 preparation: Make implicit-nullable parameters explicit (Case 212955)

### DIFF
--- a/src/Entity/BlockedEmailAddressHash.php
+++ b/src/Entity/BlockedEmailAddressHash.php
@@ -18,12 +18,12 @@ class BlockedEmailAddressHash implements BlockedEmailAddressHashInterface
 
     public static function fromEmailAddress(
         EmailAddress $emailAddress,
-        DateTimeImmutable $blockDate = null
+        ?DateTimeImmutable $blockDate = null
     ): BlockedEmailAddressHashInterface {
         return new self($emailAddress->getHash(), $blockDate);
     }
 
-    public function __construct(string $hash, DateTimeImmutable $blockDate = null)
+    public function __construct(string $hash, ?DateTimeImmutable $blockDate = null)
     {
         $this->hash = $hash;
         $this->blockDate = $blockDate ?? new DateTimeImmutable();

--- a/src/Entity/BlockedEmailAddressHashInterface.php
+++ b/src/Entity/BlockedEmailAddressHashInterface.php
@@ -7,7 +7,7 @@ use DateTimeImmutable;
 
 interface BlockedEmailAddressHashInterface
 {
-    public static function fromEmailAddress(EmailAddress $emailAddress, DateTimeImmutable $blockDate = null): self;
+    public static function fromEmailAddress(EmailAddress $emailAddress, ?DateTimeImmutable $blockDate = null): self;
 
     public function getBlockedUntilDate(DateInterval $blockDuration): DateTimeImmutable;
 }

--- a/src/Exception/EmailAddressCanNotBeHashedWithoutSecretException.php
+++ b/src/Exception/EmailAddressCanNotBeHashedWithoutSecretException.php
@@ -7,7 +7,7 @@ use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 
 class EmailAddressCanNotBeHashedWithoutSecretException extends WebfactoryNewsletterRegistrationException
 {
-    public function __construct(EmailAddress $emailAddress, $code = 0, Throwable $previous = null)
+    public function __construct(EmailAddress $emailAddress, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(
             'The email address "'.$emailAddress->getEmailAddress().'" could not be hashed as this email '

--- a/src/Exception/EmailAddressDoesNotMatchHashOfPendingOptInException.php
+++ b/src/Exception/EmailAddressDoesNotMatchHashOfPendingOptInException.php
@@ -12,7 +12,7 @@ class EmailAddressDoesNotMatchHashOfPendingOptInException extends WebfactoryNews
         EmailAddress $emailAddress,
         PendingOptInInterface $pendingOptIn,
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct(
             'The email address "'.$emailAddress->getEmailAddress().'" does not correspond to the hash of the '

--- a/src/Exception/PendingOptInClassCouldNotBeDeterminedException.php
+++ b/src/Exception/PendingOptInClassCouldNotBeDeterminedException.php
@@ -8,7 +8,7 @@ use Webfactory\NewsletterRegistrationBundle\Entity\RecipientInterface;
 
 class PendingOptInClassCouldNotBeDeterminedException extends WebfactoryNewsletterRegistrationException
 {
-    public function __construct($code = 0, Throwable $previous = null)
+    public function __construct($code = 0, ?Throwable $previous = null)
     {
         parent::__construct(
             'We were unable to determine your '.RecipientInterface::class.' implementation. Consider replacing'

--- a/src/Exception/PendingOptInIsOutdatedException.php
+++ b/src/Exception/PendingOptInIsOutdatedException.php
@@ -7,7 +7,7 @@ use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInInterface;
 
 class PendingOptInIsOutdatedException extends WebfactoryNewsletterRegistrationException
 {
-    public function __construct(PendingOptInInterface $pendingOptIn, $code = 0, Throwable $previous = null)
+    public function __construct(PendingOptInInterface $pendingOptIn, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct(
             'The PendingOptIn with uuid '.$pendingOptIn->getUuid().' is outdated and can no longer be '

--- a/src/Exception/RecipientClassCouldNotBeDeterminedException.php
+++ b/src/Exception/RecipientClassCouldNotBeDeterminedException.php
@@ -8,7 +8,7 @@ use Webfactory\NewsletterRegistrationBundle\Entity\RecipientInterface;
 
 class RecipientClassCouldNotBeDeterminedException extends WebfactoryNewsletterRegistrationException
 {
-    public function __construct($code = 0, Throwable $previous = null)
+    public function __construct($code = 0, ?Throwable $previous = null)
     {
         parent::__construct(
             'We were unable to determine your '.RecipientInterface::class.' implementation. Consider replacing'

--- a/src/StartRegistration/HoneypotType.php
+++ b/src/StartRegistration/HoneypotType.php
@@ -26,7 +26,7 @@ class HoneypotType extends AbstractType
     protected TranslatorInterface $translator;
     protected LoggerInterface $logger;
 
-    public function __construct(TranslatorInterface $translator, LoggerInterface $logger = null)
+    public function __construct(TranslatorInterface $translator, ?LoggerInterface $logger = null)
     {
         $this->translator = $translator;
         $this->logger = $logger ?: new NullLogger();


### PR DESCRIPTION
PHP 8.4 (required by Symfony 8) deprecates declaring a nullable parameter implicitly via `Type $x = null `. Adding the explicit `?` to every affected signature in the entities, form type and exceptions. Behavior is unchanged; this only silences the deprecation ahead of the version bump.