### PR TITLE
Validate the Doctrine mapping of the app-class-templates (Case 212955)

### DIFF
--- a/Resources/app-class-templates/PendingOptIn.php
+++ b/Resources/app-class-templates/PendingOptIn.php
@@ -5,12 +5,8 @@ namespace AppBundle\Newsletter\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PendingOptInRepository::class)]
-#[ORM\Table(
-    uniqueConstraints: [
-        new ORM\UniqueConstraint(name: 'emailAddressHash_unique', columns: ['emailAddressHash']),
-        new ORM\UniqueConstraint(name: 'uuid_unique', columns: ['uuid']),
-    ]
-)]
+#[ORM\UniqueConstraint(name: 'emailAddressHash_unique', columns: ['emailAddressHash'])]
+#[ORM\UniqueConstraint(name: 'uuid_unique', columns: ['uuid'])]
 class PendingOptIn extends \Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn
 {
 }

--- a/Resources/app-class-templates/Recipient.php
+++ b/Resources/app-class-templates/Recipient.php
@@ -5,13 +5,9 @@ namespace AppBundle\Newsletter\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: RecipientRepository::class)]
-#[ORM\Table(
-    name: 'wfd_newsletterRecipient',
-    uniqueConstraints: [
-        new ORM\UniqueConstraint(name: 'email_unique', columns: ['email']),
-        new ORM\UniqueConstraint(name: 'uuid_unique', columns: ['uuid']),
-    ]
-)]
+#[ORM\Table(name: 'wfd_newsletterRecipient')]
+#[ORM\UniqueConstraint(name: 'email_unique', columns: ['email'])]
+#[ORM\UniqueConstraint(name: 'uuid_unique', columns: ['uuid'])]
 class Recipient extends \Webfactory\NewsletterRegistrationBundle\Entity\Recipient
 {
 }

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "autoload-dev": {
         "psr-4": {
             "App\\": "tests/Fixtures/App",
+            "AppBundle\\Newsletter\\Entity\\": "Resources/app-class-templates",
             "Webfactory\\NewsletterRegistrationBundle\\Tests\\": "tests"
         }
     },

--- a/tests/Resources/AppClassTemplatesTest.php
+++ b/tests/Resources/AppClassTemplatesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Webfactory\NewsletterRegistrationBundle\Tests\Resources;
+
+use AppBundle\Newsletter\Entity\Newsletter as NewsletterTemplate;
+use AppBundle\Newsletter\Entity\NewsletterRepository as NewsletterRepositoryTemplate;
+use AppBundle\Newsletter\Entity\PendingOptIn as PendingOptInTemplate;
+use AppBundle\Newsletter\Entity\PendingOptInRepository as PendingOptInRepositoryTemplate;
+use AppBundle\Newsletter\Entity\Recipient as RecipientTemplate;
+use AppBundle\Newsletter\Entity\RecipientRepository as RecipientRepositoryTemplate;
+use PHPUnit\Framework\TestCase;
+use Webfactory\NewsletterRegistrationBundle\Entity\Newsletter as AbstractNewsletter;
+use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterRepository as AbstractNewsletterRepository;
+use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn as AbstractPendingOptIn;
+use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInRepository as AbstractPendingOptInRepository;
+use Webfactory\NewsletterRegistrationBundle\Entity\Recipient as AbstractRecipient;
+use Webfactory\NewsletterRegistrationBundle\Entity\RecipientRepository as AbstractRecipientRepository;
+
+class AppClassTemplatesTest extends TestCase
+{
+    /** @test */
+    public function newsletter_template_extends_abstract_newsletter(): void
+    {
+        self::assertTrue(is_subclass_of(NewsletterTemplate::class, AbstractNewsletter::class));
+    }
+
+    /** @test */
+    public function recipient_template_extends_abstract_recipient(): void
+    {
+        self::assertTrue(is_subclass_of(RecipientTemplate::class, AbstractRecipient::class));
+    }
+
+    /** @test */
+    public function pending_opt_in_template_extends_abstract_pending_opt_in(): void
+    {
+        self::assertTrue(is_subclass_of(PendingOptInTemplate::class, AbstractPendingOptIn::class));
+    }
+
+    /** @test */
+    public function newsletter_repository_template_extends_abstract_newsletter_repository(): void
+    {
+        self::assertTrue(is_subclass_of(NewsletterRepositoryTemplate::class, AbstractNewsletterRepository::class));
+    }
+
+    /** @test */
+    public function recipient_repository_template_extends_abstract_recipient_repository(): void
+    {
+        self::assertTrue(is_subclass_of(RecipientRepositoryTemplate::class, AbstractRecipientRepository::class));
+    }
+
+    /** @test */
+    public function pending_opt_in_repository_template_extends_abstract_pending_opt_in_repository(): void
+    {
+        self::assertTrue(is_subclass_of(PendingOptInRepositoryTemplate::class, AbstractPendingOptInRepository::class));
+    }
+}

--- a/tests/Resources/AppClassTemplatesTest.php
+++ b/tests/Resources/AppClassTemplatesTest.php
@@ -8,8 +8,16 @@ use AppBundle\Newsletter\Entity\PendingOptIn as PendingOptInTemplate;
 use AppBundle\Newsletter\Entity\PendingOptInRepository as PendingOptInRepositoryTemplate;
 use AppBundle\Newsletter\Entity\Recipient as RecipientTemplate;
 use AppBundle\Newsletter\Entity\RecipientRepository as RecipientRepositoryTemplate;
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\SchemaValidator;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\Newsletter as AbstractNewsletter;
+use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterInterface;
 use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterRepository as AbstractNewsletterRepository;
 use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptIn as AbstractPendingOptIn;
 use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInRepository as AbstractPendingOptInRepository;
@@ -18,6 +26,33 @@ use Webfactory\NewsletterRegistrationBundle\Entity\RecipientRepository as Abstra
 
 class AppClassTemplatesTest extends TestCase
 {
+    private EntityManager $em;
+
+    protected function setUp(): void
+    {
+        $resolveTargetEntityListener = new ResolveTargetEntityListener();
+        $resolveTargetEntityListener->addResolveTargetEntity(
+            NewsletterInterface::class,
+            NewsletterTemplate::class,
+            []
+        );
+
+        $eventManager = new EventManager();
+        $eventManager->addEventSubscriber($resolveTargetEntityListener);
+
+        $connection = DriverManager::getConnection(
+            ['driver' => 'pdo_sqlite', 'memory' => true],
+            eventManager: $eventManager,
+        );
+
+        $config = ORMSetup::createAttributeMetadataConfiguration(
+            [__DIR__.'/../../Resources/app-class-templates'],
+            isDevMode: true,
+        );
+
+        $this->em = new EntityManager($connection, $config);
+    }
+
     /** @test */
     public function newsletter_template_extends_abstract_newsletter(): void
     {
@@ -52,5 +87,73 @@ class AppClassTemplatesTest extends TestCase
     public function pending_opt_in_repository_template_extends_abstract_pending_opt_in_repository(): void
     {
         self::assertTrue(is_subclass_of(PendingOptInRepositoryTemplate::class, AbstractPendingOptInRepository::class));
+    }
+
+    /** @test */
+    public function mapping_validates_without_errors(): void
+    {
+        $errors = (new SchemaValidator($this->em))->validateMapping();
+
+        self::assertSame([], $errors);
+    }
+
+    /** @test */
+    public function newsletter_table_name_is_correct(): void
+    {
+        self::assertTrue($this->getSchema()->hasTable('wfd_newsletterNewsletter'));
+    }
+
+    /** @test */
+    public function recipient_table_name_is_correct(): void
+    {
+        self::assertTrue($this->getSchema()->hasTable('wfd_newsletterRecipient'));
+    }
+
+    /** @test */
+    public function recipient_has_unique_constraints_on_email_and_uuid(): void
+    {
+        $constrainedColumns = $this->getUniqueConstraintColumns('wfd_newsletterRecipient');
+
+        self::assertContains(['email'], $constrainedColumns);
+        self::assertContains(['uuid'], $constrainedColumns);
+    }
+
+    /** @test */
+    public function pending_opt_in_has_unique_constraints_on_email_address_hash_and_uuid(): void
+    {
+        $tableName = $this->em->getClassMetadata(PendingOptInTemplate::class)->getTableName();
+        $constrainedColumns = $this->getUniqueConstraintColumns($tableName);
+
+        self::assertContains(['emailAddressHash'], $constrainedColumns);
+        self::assertContains(['uuid'], $constrainedColumns);
+    }
+
+    private function getSchema(): \Doctrine\DBAL\Schema\Schema
+    {
+        $classes = $this->em->getMetadataFactory()->getAllMetadata();
+
+        return (new SchemaTool($this->em))->getSchemaFromMetadata($classes);
+    }
+
+    /**
+     * Returns column lists for all unique indexes/constraints on a table.
+     * Doctrine emits ORM uniqueConstraints as named unique indexes on SQLite.
+     */
+    private function getUniqueConstraintColumns(string $tableName): array
+    {
+        $table = $this->getSchema()->getTable($tableName);
+
+        $columns = array_map(
+            fn ($uc) => array_values($uc->getColumns()),
+            $table->getUniqueConstraints()
+        );
+
+        foreach ($table->getIndexes() as $index) {
+            if ($index->isUnique() && !$index->isPrimary()) {
+                $columns[] = array_values($index->getColumns());
+            }
+        }
+
+        return $columns;
     }
 }


### PR DESCRIPTION
The reference entity templates in `Resources/app-class-templates/` were shipped with PHP 8 attribute syntax but never loaded or tested, so mapping errors could go unnoticed. This PR adds a test suite for them and fixes a silent mapping defect it uncovered.

The new test class `AppClassTemplatesTest` now validates the templates without involving the main test kernel:

- Six reflection tests confirm each template class and repository extends the correct abstract base (catching the kind of drift that had already happened once — `PendingOptIn.php` had been extending `Recipient` instead of `PendingOptIn`).
- Five mapping tests build an isolated `EntityManager` against the templates directory, with a `ResolveTargetEntityListener` binding `NewsletterInterface` to the template `Newsletter` — the same `resolve_target_entities` mechanism the README tells downstream implementors to use. They assert that the Doctrine metadata loads without errors, the expected table names are generated, and the unique constraints on `Recipient` (`email`, `uuid`) and `PendingOptIn` (`emailAddressHash`, `uuid`) are present in the schema.

The test runs against its own `EntityManager` rather than the existing test kernel because that kernel already maps the Dummy entities and can only resolve `NewsletterInterface` to one concrete class. A shared kernel would be a conflict.

**Template fix** — the mapping tests immediately caught that the unique constraints in `Recipient.php` and `PendingOptIn.php` had been declared as nested arguments inside `#[ORM\Table(uniqueConstraints: [...])]`. The ORM attribute driver does not read constraints from there; it expects them as separate `#[ORM\UniqueConstraint(...)]` attributes on the class. The nested form was silently ignored, so no constraints were generated. Both templates are corrected.
