### PR TITLE
Update: Bump Doctrine to ORM 3 and collections 2 (Case 212955)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": "^8.2",
         "ext-mbstring": "*",
-        "doctrine/collections": "^1.6",
-        "doctrine/orm": "^2.0",
+        "doctrine/collections": "^2.0",
+        "doctrine/orm": "^3.0",
         "psr/log": "^3.0",
         "ramsey/uuid": "^4.0",
         "symfony/config": "^7.0",

--- a/tests/Resources/AppClassTemplatesTest.php
+++ b/tests/Resources/AppClassTemplatesTest.php
@@ -42,7 +42,6 @@ class AppClassTemplatesTest extends TestCase
 
         $connection = DriverManager::getConnection(
             ['driver' => 'pdo_sqlite', 'memory' => true],
-            eventManager: $eventManager,
         );
 
         $config = ORMSetup::createAttributeMetadataConfiguration(
@@ -50,7 +49,7 @@ class AppClassTemplatesTest extends TestCase
             isDevMode: true,
         );
 
-        $this->em = new EntityManager($connection, $config);
+        $this->em = new EntityManager($connection, $config, $eventManager);
     }
 
     /** @test */


### PR DESCRIPTION
Doctrine ORM 3 removed the annotation driver (handled in fce9de9) and requires the entity mappings to be declared explicitly (handled in 34cc2b5). With those in place, raise `doctrine/orm` to `^3.0` and `doctrine/collections` to `^2.0`. This also pulls in DBAL 4 and persistence 4 as transitive upgrades. The MappedSuperclass mapping and all repositories compile unchanged; `Collection`/`ArrayCollection` usage required no changes (generics only).

One code fix was needed: `AppClassTemplatesTest` constructed its `EntityManager` by passing `EventManager` to `DriverManager::getConnection()`, which DBAL 4 no longer accepts. Move the `EventManager` to the `EntityManager` constructor instead, which is the correct API in ORM 3 / DBAL 4.