### PR TITLE
Cleanup: Drop unused dev dependency and migrate PHPUnit annotations to attributes (Case 212955)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
 
     "require-dev": {
-        "doctrine/common": "^2.0 | ^3.0",
         "doctrine/doctrine-bundle": "^3.0",
         "phpunit/phpunit": "^11.0",
         "symfony/browser-kit": "^8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
-    colors="true">
-
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <server name="SHELL_VERBOSITY" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="KERNEL_CLASS" value="Webfactory\NewsletterRegistrationBundle\Tests\Fixtures\Kernel"/>
-        <env name="APP_ENV" value="test"/>
-        <env name="APP_DEBUG" value="0"/>
-    </php>
-
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
-
-    <testsuites>
-        <testsuite name="App Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" colors="true">
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <server name="SHELL_VERBOSITY" value="-1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+    <env name="KERNEL_CLASS" value="Webfactory\NewsletterRegistrationBundle\Tests\Fixtures\Kernel"/>
+    <env name="APP_ENV" value="test"/>
+    <env name="APP_DEBUG" value="0"/>
+  </php>
+  <testsuites>
+    <testsuite name="App Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/BlockEmails/TaskTest.php
+++ b/tests/BlockEmails/TaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\BlockEmails;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\BlockEmails\Task;
@@ -37,9 +38,7 @@ class TaskTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throws_exception_if_email_address_does_not_match_hash()
     {
         $pendingOptIn = new PendingOptIn('uuid', $this->emailAddressFactory->fromString('webfactory@example.com'));
@@ -48,9 +47,7 @@ class TaskTest extends TestCase
         $this->task->blockEmailsFor($pendingOptIn, 'other@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function saves_block()
     {
         $this->blockedEmailHashesRepository->expects($this->once())->method('save');
@@ -59,9 +56,7 @@ class TaskTest extends TestCase
         $this->task->blockEmailsFor($pendingOptIn, 'webfactory@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function replaces_older_block_if_it_exists()
     {
         $emailAddress = $this->emailAddressFactory->fromString('webfactory@example.com');
@@ -85,9 +80,7 @@ class TaskTest extends TestCase
         $this->task->blockEmailsFor($pendingOptIn, 'webfactory@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removes_PendingOpIn()
     {
         $pendingOptIn = new PendingOptIn('uuid', $this->emailAddressFactory->fromString('webfactory@example.com'));

--- a/tests/ConfirmRegistration/TaskTest.php
+++ b/tests/ConfirmRegistration/TaskTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\ConfirmRegistration;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -57,9 +58,7 @@ class TaskTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throws_exception_if_PendingOptIn_is_outdated()
     {
         $pendingOptIn = new PendingOptIn(
@@ -73,9 +72,7 @@ class TaskTest extends TestCase
         $this->task->confirmRegistration($pendingOptIn, 'other@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throws_exception_if_email_address_does_not_match_hash()
     {
         $pendingOptIn = new PendingOptIn('uuid', $this->emailAddressFactory->fromString('webfactory@example.com'));
@@ -84,9 +81,7 @@ class TaskTest extends TestCase
         $this->task->confirmRegistration($pendingOptIn, 'other@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function saves_recipient()
     {
         $this->recipientRepo->expects($this->once())->method('save');
@@ -95,9 +90,7 @@ class TaskTest extends TestCase
         $this->task->confirmRegistration($pendingOptIn, 'webfactory@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removes_pending_opt_in()
     {
         $pendingOptIn = new PendingOptIn('uuid', $this->emailAddressFactory->fromString('webfactory@example.com'));
@@ -106,9 +99,7 @@ class TaskTest extends TestCase
         $this->task->confirmRegistration($pendingOptIn, 'webfactory@example.com');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function writes_success_flash()
     {
         $pendingOptIn = new PendingOptIn('uuid', $this->emailAddressFactory->fromString('webfactory@example.com'));

--- a/tests/DeleteOutdatedBlockedEmailAddresses/TaskTest.php
+++ b/tests/DeleteOutdatedBlockedEmailAddresses/TaskTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\DeleteOutdatedBlockedEmailAddresses;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\DeleteOutdatedPendingOptIns\Task;
@@ -23,9 +24,7 @@ class TaskTest extends TestCase
         $this->task = new Task($this->repository, self::BLOCK_EMAIL_DURATION_IN_DAYS);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delegates_to_repository(): void
     {
         $this->repository
@@ -35,9 +34,7 @@ class TaskTest extends TestCase
         $this->task->deleteOutdatedPendingOptIns();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sets_threshold_date_from_now_if_called_without_one(): void
     {
         $expected = new DateTimeImmutable('-'.self::BLOCK_EMAIL_DURATION_IN_DAYS.' hour');

--- a/tests/DeleteOutdatedPendingOptIns/TaskTest.php
+++ b/tests/DeleteOutdatedPendingOptIns/TaskTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\DeleteOutdatedPendingOptIns;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\DeleteOutdatedPendingOptIns\Task;
@@ -23,9 +24,7 @@ class TaskTest extends TestCase
         $this->task = new Task($this->repository, self::TIME_LIMIT_FOR_OPT_IN_IN_HOURS);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delegates_to_repository(): void
     {
         $this->repository
@@ -35,9 +34,7 @@ class TaskTest extends TestCase
         $this->task->deleteOutdatedPendingOptIns();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sets_threshold_date_from_now_if_called_without_one(): void
     {
         $expected = new DateTimeImmutable('-'.self::TIME_LIMIT_FOR_OPT_IN_IN_HOURS.' hour');

--- a/tests/DeleteRegistration/TaskTest.php
+++ b/tests/DeleteRegistration/TaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\DeleteRegistration;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -35,9 +36,7 @@ class TaskTest extends TestCase
         $this->task = new Task($this->recipientRepo, $this->requestStack, $this->translator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removes_recipient()
     {
         $recipient = new Recipient('uuid', new EmailAddress('webfactory@example.com', null));
@@ -46,9 +45,7 @@ class TaskTest extends TestCase
         $this->task->deleteRegistration($recipient);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function writes_success_flash()
     {
         $recipient = new Recipient('uuid', new EmailAddress('webfactory@example.com', null));

--- a/tests/EditRegistration/SendLinkTaskTest.php
+++ b/tests/EditRegistration/SendLinkTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\StartRegistration;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\MailerInterface;
@@ -30,9 +31,7 @@ class SendLinkTaskTest extends TestCase
         $this->task = new SendLinkTask($this->mailer, self::SENDER, $this->twig, $this->urlGenerator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sends_edit_registration_email()
     {
         $recipient = new Recipient(null, new EmailAddress('receiver@example.com', null));

--- a/tests/EditRegistration/TaskTest.php
+++ b/tests/EditRegistration/TaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\EditRegistration;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -35,9 +36,7 @@ class TaskTest extends TestCase
         $this->task = new Task($this->recipientRepo, $this->requestStack, $this->translator);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function saves_recipient()
     {
         $recipient = new Recipient('uuid', new EmailAddress('webfactory@example.com', null));
@@ -46,9 +45,7 @@ class TaskTest extends TestCase
         $this->task->editRegistration($recipient);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function writes_success_flash()
     {
         $recipient = new Recipient('uuid', new EmailAddress('webfactory@example.com', null));

--- a/tests/Entity/BlockedEmailAddressHashRepositoryTest.php
+++ b/tests/Entity/BlockedEmailAddressHashRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHash;
 use Webfactory\NewsletterRegistrationBundle\Entity\BlockedEmailAddressHashRepositoryInterface;
@@ -27,9 +28,7 @@ class BlockedEmailAddressHashRepositoryTest extends KernelTestCase
             ->getRepository(BlockedEmailAddressHash::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByEmailAddress_returns_BlockedEmailAddressHash_if_it_exists(): void
     {
         $emailAddress = new EmailAddress('webfactory@example.com', 'secret');
@@ -38,9 +37,7 @@ class BlockedEmailAddressHashRepositoryTest extends KernelTestCase
         $this->assertNotEmpty($this->repository->findByEmailAddress($emailAddress));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByEmailAddress_returns_null_if_no_matching_BlockedEmailAddressHash_exists(): void
     {
         $this->assertNull(
@@ -48,9 +45,7 @@ class BlockedEmailAddressHashRepositoryTest extends KernelTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeOutdated_removes_outdated_ones(): void
     {
         BlockedEmailAddressHashFactory::createOne(['blockDate' => new DateTimeImmutable('2000-01-01')]);
@@ -61,9 +56,7 @@ class BlockedEmailAddressHashRepositoryTest extends KernelTestCase
         $this->assertCount(0, $this->repository->findAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeOutdated_does_not_remove_current_ones(): void
     {
         BlockedEmailAddressHashFactory::createOne(['blockDate' => new DateTimeImmutable('-1d')]);

--- a/tests/Entity/EmailAddressTest.php
+++ b/tests/Entity/EmailAddressTest.php
@@ -2,15 +2,14 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Exception\EmailAddressCanNotBeHashedWithoutSecretException;
 
 class EmailAddressTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function email_address_gets_normalized()
     {
         $this->assertEquals(
@@ -19,9 +18,7 @@ class EmailAddressTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function email_address_gets_hashed()
     {
         $this->assertNotEmpty(
@@ -29,9 +26,7 @@ class EmailAddressTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throws_exception_when_trying_to_hash_without_secret()
     {
         $this->expectException(EmailAddressCanNotBeHashedWithoutSecretException::class);

--- a/tests/Entity/NewsletterRepositoryTest.php
+++ b/tests/Entity/NewsletterRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterRepository;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
@@ -25,9 +26,7 @@ class NewsletterRepositoryTest extends KernelTestCase
             ->getRepository(Newsletter::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findVisible_returns_visible_newsletters()
     {
         NewsletterFactory::createOne();
@@ -38,9 +37,7 @@ class NewsletterRepositoryTest extends KernelTestCase
         $this->assertContainsOnly(Newsletter::class, $newsletters);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findVisible_does_not_return_invisible_newsletters()
     {
         NewsletterFactory::createOne(['visible' => false]);
@@ -48,9 +45,7 @@ class NewsletterRepositoryTest extends KernelTestCase
         $this->assertEmpty($this->repository->findVisible());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findVisible_orders_by_rank()
     {
         NewsletterFactory::createOne(['name' => '1', 'rank' => 1]);

--- a/tests/Entity/NewsletterTest.php
+++ b/tests/Entity/NewsletterTest.php
@@ -2,16 +2,15 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
 
 class NewsletterTest extends TestCase
 {
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
+    #[Test]
     public function can_be_constructed()
     {
         new Newsletter(null, 'newsletter name');

--- a/tests/Entity/PendingOptInFactoryTest.php
+++ b/tests/Entity/PendingOptInFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use App\PendingOptIn as AppPendingOptIn;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInFactory;
@@ -20,9 +21,7 @@ class PendingOptInFactoryTest extends TestCase
         $this->factory = new PendingOptInFactory();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromRegistrationFormData_without_newsletter_choices(): void
     {
         // The PendingOptInFactory uses get_declared_classes() to find a PendingOptInInterface
@@ -37,9 +36,7 @@ class PendingOptInFactoryTest extends TestCase
         $this->assertEquals('webfactory@example.com', (string) $pendingOptIn->getEmailAddress());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fromRegistrationFormData_with_newsletter_choices(): void
     {
         // The PendingOptInFactory uses get_declared_classes() to find a PendingOptInInterface

--- a/tests/Entity/PendingOptInRepositoryTest.php
+++ b/tests/Entity/PendingOptInRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Entity\PendingOptInRepositoryInterface;
@@ -27,9 +28,7 @@ class PendingOptInRepositoryTest extends KernelTestCase
             ->getRepository(PendingOptIn::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByEmailAddress_returns_PendingOptIn_if_it_exists(): void
     {
         $emailAddress = new EmailAddress('webfactory@example.com', 'secret');
@@ -41,9 +40,7 @@ class PendingOptInRepositoryTest extends KernelTestCase
         $this->assertEquals($proxy->getUuid(), $result->getUuid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function findByEmailAddress_returns_null_if_no_matching_PendingOptIn_exists(): void
     {
         $this->assertNull(
@@ -51,9 +48,7 @@ class PendingOptInRepositoryTest extends KernelTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeOutdated_removes_outdated_ones(): void
     {
         PendingOptInFactory::createOne(['registrationDate' => new DateTimeImmutable('2000-01-01')]);
@@ -64,9 +59,7 @@ class PendingOptInRepositoryTest extends KernelTestCase
         $this->assertCount(0, $this->repository->findAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeOutdated_does_not_remove_current_ones(): void
     {
         PendingOptInFactory::createOne(['registrationDate' => new DateTimeImmutable('-1h')]);

--- a/tests/Entity/PendingOptInTest.php
+++ b/tests/Entity/PendingOptInTest.php
@@ -4,6 +4,8 @@ namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use DateInterval;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Exception\EmailAddressDoesNotMatchHashOfPendingOptInException;
@@ -13,9 +15,7 @@ use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptIn;
 
 class PendingOptInTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function uuid_is_added_if_omitted(): void
     {
         $this->assertNotEmpty(
@@ -23,9 +23,7 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registrationDate_is_added_if_omitted(): void
     {
         $this->assertEqualsWithDelta(
@@ -35,11 +33,8 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
+    #[Test]
     public function static_construction_with_newsletters(): void
     {
         PendingOptIn::fromRegistrationFormData(
@@ -53,11 +48,8 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
+    #[Test]
     public function static_construction_without_newsletters(): void
     {
         PendingOptIn::fromRegistrationFormData(
@@ -67,9 +59,7 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function static_construction_without_email_address_returns_NULL(): void
     {
         $this->assertNull(
@@ -79,9 +69,7 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setEmailAddressIfItMatchesStoredHash_sets_EmailAddress_if_it_matches_stored_Hash(): void
     {
         $emailAddressFixture = new EmailAddress('webfactory@example.com', 'secret');
@@ -92,9 +80,7 @@ class PendingOptInTest extends TestCase
         $this->assertEquals($emailAddressFixture, $pendingOptIn->getEmailAddress());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setEmailAddressIfItMatchesStoredHash_throws_Exception_if_email_address_does_not_match(): void
     {
         $this->expectException(EmailAddressDoesNotMatchHashOfPendingOptInException::class);
@@ -104,9 +90,7 @@ class PendingOptInTest extends TestCase
         $pendingOptIn->setEmailAddressIfItMatchesStoredHash(new EmailAddress('other@example.com', 'secret'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setEmailAddressIfItMatchesStoredHash_throws_Exception_if_secret_does_not_match(): void
     {
         $this->expectException(EmailAddressDoesNotMatchHashOfPendingOptInException::class);
@@ -116,9 +100,7 @@ class PendingOptInTest extends TestCase
         $pendingOptIn->setEmailAddressIfItMatchesStoredHash(new EmailAddress('webfactory@example.com', 'other-secret'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isOutdated_returns_true_if_outdated(): void
     {
         $pendingOptIn = new PendingOptIn(
@@ -133,9 +115,7 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isOutdated_returns_false_if_not_outdated(): void
     {
         $pendingOptIn = new PendingOptIn(
@@ -150,9 +130,7 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAllowedToReceiveAnotherOptInEmail_returns_true_if_enough_time_passed_since_registration(): void
     {
         $pendingOptIn = new PendingOptIn(
@@ -167,9 +145,7 @@ class PendingOptInTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isAllowedToReceiveAnotherOptInEmail_returns_false_if_too_little_time_passed_since_registration(): void
     {
         $pendingOptIn = new PendingOptIn(

--- a/tests/Entity/RecipientFactoryTest.php
+++ b/tests/Entity/RecipientFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use App\Recipient as AppRecipient;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Entity\RecipientFactory;
@@ -11,9 +12,7 @@ use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\PendingOptIn;
 
 class RecipientFactoryTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function fromPendingOptIn()
     {
         // The RecipientFactory uses get_declared_classes() to find a RecipientInterface

--- a/tests/Entity/RecipientRepositoryTest.php
+++ b/tests/Entity/RecipientRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Entity\RecipientRepositoryInterface;
@@ -26,9 +27,7 @@ class RecipientRepositoryTest extends KernelTestCase
             ->getRepository(Recipient::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEmailAddressAlreadyRegistered_returns_true_if_already_registered()
     {
         $emailAddress = new EmailAddress('webfactory@example.com', null);
@@ -40,9 +39,7 @@ class RecipientRepositoryTest extends KernelTestCase
         $this->assertEquals($registeredRecipient->getUuid(), $retrievedRecipient->getUuid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEmailAddressAlreadyRegistered_returns_null_if_not_already_registered()
     {
         $this->assertNull(

--- a/tests/Entity/RecipientTest.php
+++ b/tests/Entity/RecipientTest.php
@@ -3,6 +3,8 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Entity;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\EmailAddress;
 use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Newsletter;
@@ -11,9 +13,7 @@ use Webfactory\NewsletterRegistrationBundle\Tests\Entity\Dummy\Recipient;
 
 class RecipientTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function uuid_is_added_if_omitted()
     {
         $this->assertNotEmpty(
@@ -21,9 +21,7 @@ class RecipientTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function optInDate_is_added_if_omitted()
     {
         $this->assertEqualsWithDelta(
@@ -33,9 +31,7 @@ class RecipientTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function static_construction_with_newsletters()
     {
         $newslettersForPendingOptIn = [new Newsletter(1, 'newsletter 1'), new Newsletter(2, 'newsletter 2')];
@@ -48,11 +44,8 @@ class RecipientTest extends TestCase
         $this->assertEquals($newslettersForPendingOptIn, $recipient->getNewsletters());
     }
 
-    /**
-     * @test
-     *
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
+    #[Test]
     public function static_construction_without_newsletters()
     {
         $pendingOptIn = new PendingOptIn('uuid', new EmailAddress('webfactory@example.com', 'secret'));

--- a/tests/Functional/ControllerTest.php
+++ b/tests/Functional/ControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -11,7 +12,7 @@ class ControllerTest extends WebTestCase
     use Factories;
     use ResetDatabase;
 
-    /** @test */
+    #[Test]
     public function start_registration_route_renders_the_registration_form(): void
     {
         $client = static::createClient();
@@ -21,7 +22,7 @@ class ControllerTest extends WebTestCase
         self::assertSelectorExists('form');
     }
 
-    /** @test */
+    #[Test]
     public function edit_registration_route_returns_not_found_for_unknown_uuid(): void
     {
         $client = static::createClient();

--- a/tests/Resources/AppClassTemplatesTest.php
+++ b/tests/Resources/AppClassTemplatesTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\SchemaValidator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Webfactory\NewsletterRegistrationBundle\Entity\Newsletter as AbstractNewsletter;
 use Webfactory\NewsletterRegistrationBundle\Entity\NewsletterInterface;
@@ -53,43 +54,43 @@ class AppClassTemplatesTest extends TestCase
         $this->em = new EntityManager($connection, $config, $eventManager);
     }
 
-    /** @test */
+    #[Test]
     public function newsletter_template_extends_abstract_newsletter(): void
     {
         self::assertTrue(is_subclass_of(NewsletterTemplate::class, AbstractNewsletter::class));
     }
 
-    /** @test */
+    #[Test]
     public function recipient_template_extends_abstract_recipient(): void
     {
         self::assertTrue(is_subclass_of(RecipientTemplate::class, AbstractRecipient::class));
     }
 
-    /** @test */
+    #[Test]
     public function pending_opt_in_template_extends_abstract_pending_opt_in(): void
     {
         self::assertTrue(is_subclass_of(PendingOptInTemplate::class, AbstractPendingOptIn::class));
     }
 
-    /** @test */
+    #[Test]
     public function newsletter_repository_template_extends_abstract_newsletter_repository(): void
     {
         self::assertTrue(is_subclass_of(NewsletterRepositoryTemplate::class, AbstractNewsletterRepository::class));
     }
 
-    /** @test */
+    #[Test]
     public function recipient_repository_template_extends_abstract_recipient_repository(): void
     {
         self::assertTrue(is_subclass_of(RecipientRepositoryTemplate::class, AbstractRecipientRepository::class));
     }
 
-    /** @test */
+    #[Test]
     public function pending_opt_in_repository_template_extends_abstract_pending_opt_in_repository(): void
     {
         self::assertTrue(is_subclass_of(PendingOptInRepositoryTemplate::class, AbstractPendingOptInRepository::class));
     }
 
-    /** @test */
+    #[Test]
     public function mapping_validates_without_errors(): void
     {
         $errors = (new SchemaValidator($this->em))->validateMapping();
@@ -97,19 +98,19 @@ class AppClassTemplatesTest extends TestCase
         self::assertSame([], $errors);
     }
 
-    /** @test */
+    #[Test]
     public function newsletter_table_name_is_correct(): void
     {
         self::assertTrue($this->getSchema()->hasTable('wfd_newsletterNewsletter'));
     }
 
-    /** @test */
+    #[Test]
     public function recipient_table_name_is_correct(): void
     {
         self::assertTrue($this->getSchema()->hasTable('wfd_newsletterRecipient'));
     }
 
-    /** @test */
+    #[Test]
     public function recipient_has_unique_constraints_on_email_and_uuid(): void
     {
         $constrainedColumns = $this->getUniqueConstraintColumns('wfd_newsletterRecipient');
@@ -118,7 +119,7 @@ class AppClassTemplatesTest extends TestCase
         self::assertContains(['uuid'], $constrainedColumns);
     }
 
-    /** @test */
+    #[Test]
     public function pending_opt_in_has_unique_constraints_on_email_address_hash_and_uuid(): void
     {
         $tableName = $this->em->getClassMetadata(PendingOptInTemplate::class)->getTableName();

--- a/tests/StartRegistration/EmailAddressTypeTest.php
+++ b/tests/StartRegistration/EmailAddressTypeTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\StartRegistration;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\FormInterface;
@@ -43,9 +44,7 @@ class EmailAddressTypeTest extends TypeTestCase
         $this->form = $this->factory->createBuilder()->add('emailAddress', EmailAddressType::class)->getForm();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_without_email_address()
     {
         $this->form->submit([
@@ -57,9 +56,7 @@ class EmailAddressTypeTest extends TypeTestCase
         $this->assertEquals((new NotBlank())->message, $this->form->getErrors(true, true)->current()->getMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_with_invalid_email_address()
     {
         $this->form->submit([
@@ -71,9 +68,7 @@ class EmailAddressTypeTest extends TypeTestCase
         $this->assertEquals((new Email())->message, $this->form->getErrors(true, true)->current()->getMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_with_blocked_email_address()
     {
         $emailAddress = $this->emailAddressFactory->fromString('webfactory@example.com');
@@ -97,9 +92,7 @@ class EmailAddressTypeTest extends TypeTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_with_already_registering_email_address_if_not_enough_time_has_passed()
     {
         $veryRecentPendingOptIn = new PendingOptIn(null, $this->emailAddressFactory->fromString('webfactory@example.com'));
@@ -121,9 +114,7 @@ class EmailAddressTypeTest extends TypeTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_validate_with_already_registering_email_address_if_enough_time_has_passed()
     {
         $oldPendingOptIn = new PendingOptIn(
@@ -147,9 +138,7 @@ class EmailAddressTypeTest extends TypeTestCase
         $this->assertEquals('webfactory@example.com', $emailAddress->getEmailAddress());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function provides_EmailAddress_if_submitted_with_valid_data()
     {
         $this->form->submit([

--- a/tests/StartRegistration/HandleRegistrationSubmissionTaskTest.php
+++ b/tests/StartRegistration/HandleRegistrationSubmissionTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Webfactory\NewsletterRegistrationBundle\StartRegistration;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
@@ -37,9 +38,7 @@ class HandleRegistrationSubmissionTaskTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function runs_SendLinkTask_if_user_is_already_registered()
     {
         $pendingOptIn = new PendingOptIn(null, new EmailAddress('webfactory@example.org', 'secret'));
@@ -62,9 +61,7 @@ class HandleRegistrationSubmissionTaskTest extends TestCase
         $this->task->handleRegistrationSubmission($pendingOptIn);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function runs_StartRegistrationTask_if_user_is_not_yet_registered()
     {
         $pendingOptIn = new PendingOptIn(null, new EmailAddress('webfactory@example.org', 'secret'));

--- a/tests/StartRegistration/HoneypotTypeTest.php
+++ b/tests/StartRegistration/HoneypotTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\StartRegistration;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\PreloadedExtension;
@@ -22,9 +23,7 @@ class HoneypotTypeTest extends TypeTestCase
         $this->form = $this->factory->createBuilder()->add('url', HoneypotType::class)->getForm();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function is_valid_if_empty_honeypot_is_submitted(): void
     {
         $this->form->submit(['url' => '']);
@@ -32,9 +31,7 @@ class HoneypotTypeTest extends TypeTestCase
         $this->assertTrue($this->form->isValid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function is_not_valid_if_honeypot_is_not_submitted_at_all(): void
     {
         $this->form->submit([]);
@@ -46,9 +43,7 @@ class HoneypotTypeTest extends TypeTestCase
         $this->assertEquals(HoneypotType::ERROR_MESSAGE_HONEYPOT_NOT_SUBMITTED, $errors->current()->getMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function is_not_valid_if_honeypot_was_filled_in(): void
     {
         $this->form->submit(['url' => 'spam-url']);

--- a/tests/StartRegistration/TaskTest.php
+++ b/tests/StartRegistration/TaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\NewsletterRegistrationBundle\Tests\StartRegistration;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\MailerInterface;
@@ -41,9 +42,7 @@ class TaskTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function saves_PendingOptIn()
     {
         $pendingOptIn = new PendingOptIn(null, new EmailAddress('receiver@example.com', 'secret'));
@@ -56,9 +55,7 @@ class TaskTest extends TestCase
         $this->task->startRegistration($pendingOptIn);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removes_outdated_PendingOptIn_if_it_exists_and_saves_new_one()
     {
         $outdatedPendingOptIn = new PendingOptIn(null, new EmailAddress('webfactory@example.com', 'secret'));
@@ -80,9 +77,7 @@ class TaskTest extends TestCase
         $this->task->startRegistration($pendingOptIn);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sends_opt_in_email()
     {
         $pendingOptIn = new PendingOptIn(null, new EmailAddress('receiver@example.com', 'secret'));

--- a/tests/StartRegistration/TypeTest.php
+++ b/tests/StartRegistration/TypeTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\NewsletterRegistrationBundle\Tests\StartRegistration;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
@@ -53,18 +54,14 @@ class TypeTest extends TypeTestCase
         parent::setUp();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function view_has_no_newsletter_choices_element_if_there_are_no_choices(): void
     {
         $formView = $this->factory->create(StartRegistrationType::class)->createView();
         $this->assertArrayNotHasKey(startRegistrationType::ELEMENT_NEWSLETTERS, $formView->vars['form']->children);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function view_has_no_newsletter_choice_element_if_there_is_exactly_one_choice(): void
     {
         $this->setUpOneNewsletter();
@@ -73,9 +70,7 @@ class TypeTest extends TypeTestCase
         $this->assertArrayNotHasKey(startRegistrationType::ELEMENT_NEWSLETTERS, $formView->vars['form']->children);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function view_contains_newsletter_choice_element_if_there_is_more_than_one_choice(): void
     {
         $this->setUpTwoNewsletters();
@@ -91,9 +86,7 @@ class TypeTest extends TypeTestCase
         $this->assertEquals($this->newsletter2->getName(), $newslettersVars['choices'][1]->label);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_without_honeypot()
     {
         $form = $this->factory->create(StartRegistrationType::class);
@@ -109,9 +102,7 @@ class TypeTest extends TypeTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_with_filled_honeypot()
     {
         $form = $this->factory->create(StartRegistrationType::class);
@@ -125,9 +116,7 @@ class TypeTest extends TypeTestCase
         $this->assertEquals(HoneypotType::ERROR_MESSAGE_HONEYPOT_FILLED, $form->getErrors()->current()->getMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_without_email_address()
     {
         $form = $this->factory->create(StartRegistrationType::class);
@@ -141,9 +130,7 @@ class TypeTest extends TypeTestCase
         $this->assertEquals((new NotBlank())->message, $form->getErrors(true, true)->current()->getMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_with_invalid_email_address()
     {
         $form = $this->factory->create(StartRegistrationType::class);
@@ -158,9 +145,7 @@ class TypeTest extends TypeTestCase
         $this->assertEquals((new Email())->message, $form->getErrors(true, true)->current()->getMessage());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_with_already_registering_email_address_if_not_enough_time_has_passed()
     {
         $veryRecentPendingOptIn = new PendingOptIn(null, new EmailAddress('webfactory@example.com', 'secret'));
@@ -185,9 +170,7 @@ class TypeTest extends TypeTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_validate_with_already_registering_email_address_if_enough_time_has_passed()
     {
         $oldPendingOptIn = new PendingOptIn(
@@ -209,9 +192,7 @@ class TypeTest extends TypeTestCase
         $this->assertTrue($form->isValid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_validate_if_newsletter_choices_exist_but_none_was_selected()
     {
         $this->setUpTwoNewsletters();
@@ -232,9 +213,7 @@ class TypeTest extends TypeTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function provides_PendingOptIn_if_submitted_with_valid_data_without_newsletter_choices()
     {
         $pendingOptIn = new PendingOptIn(null, new EmailAddress('webfactory@example.com', 'secret'));
@@ -261,9 +240,7 @@ class TypeTest extends TypeTestCase
         $this->assertEquals($pendingOptIn, $form->getData());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function provides_PendingOptIn_if_submitted_with_valid_data_and_newsletter_choices()
     {
         $this->setUpTwoNewsletters();


### PR DESCRIPTION

- Remove `doctrine/common` from `require-dev` — the `Collections` classes are provided by `doctrine/collections` (already in `require`) and `Doctrine\Common\EventManager` by `doctrine/event-manager` (transitive via `doctrine/orm`). Confirmed clean with `composer-require-checker`.
- Migrate all PHPUnit `@test` and `@doesNotPerformAssertions` doc-annotations to `#[Test]` and `#[DoesNotPerformAssertions]` PHP 8 attributes across 24 test files. These annotations are deprecated in PHPUnit 11 and removed in PHPUnit 12.
- Update `phpunit.xml.dist` schema URL from `11.0` to `11.5` and rename `<coverage>` to `<source>`, clearing the last PHPUnit deprecation warning.
