### PR TITLE
Make app-class-templates use wfDynamic-compliant JOIN table name (Case 212955)

### DIFF
--- a/Resources/app-class-templates/Recipient.php
+++ b/Resources/app-class-templates/Recipient.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\AssociationOverrides([
     new ORM\AssociationOverride(
         name: 'categories',
-        joinTable: new ORM\JoinTable(name: 'wfd_newsletterRecipient_category'),
+        joinTable: new ORM\JoinTable(name: 'wfd_newsletterSubscription'),
         joinColumns: [new ORM\JoinColumn(onDelete: 'CASCADE')],
         inverseJoinColumns: [new ORM\JoinColumn(name: 'category_id', onDelete: 'CASCADE')],
     ),

--- a/tests/Resources/AppClassTemplatesTest.php
+++ b/tests/Resources/AppClassTemplatesTest.php
@@ -113,6 +113,12 @@ class AppClassTemplatesTest extends TestCase
     }
 
     #[Test]
+    public function recipient_subscription_join_table_name_is_correct(): void
+    {
+        self::assertTrue($this->getSchema()->hasTable('wfd_newsletterSubscription'));
+    }
+
+    #[Test]
     public function recipient_has_unique_constraints_on_email_and_uuid(): void
     {
         $constrainedColumns = $this->getUniqueConstraintColumns('wfd_newsletterRecipient');


### PR DESCRIPTION
Our internal CMS wfDynamic seems to expect this table name.